### PR TITLE
Изменил паттерн для запуска линтинга

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "karma": "karma start karma.conf.js",
-    "lint": "eslint ./*-module",
+    "lint": "eslint \"./*-module/**/*.js\"",
     "test": "npm run lint && npm run karma"
   },
   "repository": {


### PR DESCRIPTION
У нескольких учеников на Windows сыпется ошибка в момент линтинга:

No files matching the pattern "./*-module" were found.

Судя по тому, что я прочитал вот тут - https://medium.com/@jakubsynowiec/you-should-always-quote-your-globs-in-npm-scripts-621887a2a784
Проблема в том, что такие глобальные пути по-другому воспринимаются не в Unix системах.